### PR TITLE
fix:styled-components-next.js-integration

### DIFF
--- a/components/Layout.tsx
+++ b/components/Layout.tsx
@@ -25,17 +25,14 @@ const navbarItems = [
   },
 ];
 
-
 export default function Layout({
   children,
 }: {
-  children: JSX.Element;
-}): JSX.Element {
+  children: React.ReactNode;
+}): React.ReactNode {
   return (
     <Wrapper>
-      <NavBar
-        navbarItems={navbarItems}
-      />
+      <NavBar navbarItems={navbarItems} />
       <h1>Layout</h1>
       {children}
     </Wrapper>

--- a/components/LinkWrapper.tsx
+++ b/components/LinkWrapper.tsx
@@ -7,7 +7,7 @@ const StyledLink = styled(Link)`
 
 interface ILinkWrapper {
   href: string;
-  children: JSX.Element | string;
+  children: React.ReactNode | string;
 }
 
 export default function LinkWrapper({ href, children }: ILinkWrapper) {

--- a/components/NavBar.tsx
+++ b/components/NavBar.tsx
@@ -26,7 +26,7 @@ interface INavBarItem {
 
 interface INavBar {
   navbarItems: INavBarItem[];
-  logo?: JSX.Element | string;
+  logo?: React.ReactNode | string;
 }
 
 export default function NavBar({

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,9 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {}
+const nextConfig = {
+  reactStrictMode: true,
+  compiler: {
+    styledComponents: true,
+  },
+};
 
-module.exports = nextConfig
+module.exports = nextConfig;


### PR DESCRIPTION
The attached error was showing because of the `styled-components` hydration.

Added extra config settings to the `next-config.js` and this solved the issue.

Attached screenshot:
![Screenshot 2023-12-02 at 5 03 48 pm](https://github.com/portfolio-catalin-pirtiu/personal-library/assets/102763743/f44926eb-59e9-44e1-abb8-7ab67fdcc857)
