### PR TITLE
fix/change-the-BookForm-initial-values

### DIFF
--- a/components/books/Book.tsx
+++ b/components/books/Book.tsx
@@ -1,4 +1,4 @@
-import { IBook, IBookWithAuthor } from '../../lib/definitions';
+import { IDbBook, IBookWithAuthor } from '../../lib/definitions';
 import styled from 'styled-components';
 import Button from '../shared/Button';
 import { colors } from '../../lib/colors';
@@ -47,7 +47,8 @@ export default function Book({
   stop_reading,
 }: IBookWithAuthor) {
   const [isEditing, setIsEditing] = useState(false);
-  const editBookInitialValues: IBook = {
+  const editBookInitialValues: IDbBook = {
+    id: id,
     author_id: author_id,
     title: title,
     read: read,

--- a/components/books/BookForm.tsx
+++ b/components/books/BookForm.tsx
@@ -8,7 +8,7 @@ import {
 } from 'formik';
 import styled from 'styled-components';
 import toast from 'react-hot-toast';
-import { IBook } from '../../lib/definitions';
+import { IDbBook } from '../../lib/definitions';
 import { Book } from '../../lib/classes';
 import useFetchAuthors from '../../lib/useFetchAuthors';
 import { booksApiUrl, authorsApiUrl } from '../../lib/constants';
@@ -32,7 +32,8 @@ const SubmitButton = styled.button<{ disabled: boolean }>`
   opacity: ${({ disabled }) => disabled && '0.5'};
 `;
 
-const defaultInitialValues: IBook = {
+const defaultInitialValues: IDbBook = {
+  id: '',
   author_id: '',
   title: '',
   read: false,
@@ -44,7 +45,7 @@ const defaultInitialValues: IBook = {
 };
 
 interface IBookForm {
-  initialValues: IBook;
+  initialValues: IDbBook;
   action: 'newBook' | 'editBook';
   isEditing?: boolean;
   setIsEditing?: (isEditing: boolean) => void;

--- a/pages/books/new.tsx
+++ b/pages/books/new.tsx
@@ -1,7 +1,8 @@
-import { IBook } from '../../lib/definitions';
+import { IDbBook } from '../../lib/definitions';
 import BookForm from '../../components/books/BookForm';
 
-const initialValues: IBook = {
+const initialValues: IDbBook = {
+  id: '',
   author_id: '',
   title: '',
   read: false,


### PR DESCRIPTION
### Fix
Added the `id` property to the `BookForm` component.

This facilitates the use of `id` property within the `BookForm` component when editing a book.