### PR TITLE
refactor/change-color-codes

### DIFF
--- a/lib/colors.ts
+++ b/lib/colors.ts
@@ -1,6 +1,6 @@
 export const colors = {
-  green: '#DBEDDB',
-  blue: '#D3E5EF',
-  red: '#FFE2DD',
-  gray: '#f2f2f2',
+  green: 'hsl(120, 33%, 89%)',
+  blue: 'hsl(201, 47%, 88%)',
+  red: 'hsl(9, 100%, 93%)',
+  gray: 'hsl(0, 0%, 95%)',
 };


### PR DESCRIPTION
### Refactor
 I changed the colour code to `hsl` because they are easier to manipulate when I want to change the colour tone.