### PR TITLE
fix/BookForm-add-missing-values

### DIFF
--- a/components/books/BookForm.tsx
+++ b/components/books/BookForm.tsx
@@ -133,13 +133,14 @@ export default function BookForm({
               <ErrorMsg name="title" component="div" />
             </InputGroup>
 
-            <InputGroup>
-              <Input type="hidden" name="read" />
-            </InputGroup>
+            {/* <InputGroup>
+              <Input type="hidden" name="read" value="alpha" />
+            </InputGroup> */}
+            {/* <input type="input" name="read" value="true" readOnly />
 
             <InputGroup>
               <Input type="hidden" name="in_progress" />
-            </InputGroup>
+            </InputGroup> */}
 
             <InputGroup>
               <Label htmlFor="rating">

--- a/components/books/BookForm.tsx
+++ b/components/books/BookForm.tsx
@@ -39,6 +39,8 @@ const defaultInitialValues: IDbBook = {
   read: false,
   in_progress: false,
   rating: 0,
+  stop_reading: '',
+  start_reading: '',
   publisher: '',
   edition: '',
   notes: '',

--- a/components/books/BookForm.tsx
+++ b/components/books/BookForm.tsx
@@ -133,15 +133,6 @@ export default function BookForm({
               <ErrorMsg name="title" component="div" />
             </InputGroup>
 
-            {/* <InputGroup>
-              <Input type="hidden" name="read" value="alpha" />
-            </InputGroup> */}
-            {/* <input type="input" name="read" value="true" readOnly />
-
-            <InputGroup>
-              <Input type="hidden" name="in_progress" />
-            </InputGroup> */}
-
             <InputGroup>
               <Label htmlFor="rating">
                 Rating

--- a/pages/books/index.tsx
+++ b/pages/books/index.tsx
@@ -20,6 +20,7 @@ const Wrapper = styled.div`
 export default function Books() {
   const { books, setBooks } = useFetchBooks(booksApiUrl);
   const { authors } = useFetchAuthors(authorsApiUrl);
+  
   function handleUpdateBooks(updatedBook: IDbBook) {
     const updatedBooks = books.map((book) => {
       if (book.book_id === updatedBook.book_id) {
@@ -28,6 +29,7 @@ export default function Books() {
           updatedBook
         );
         return {
+          ...book,
           ...updatedBook,
           first_name: authorFirstName,
           last_name: authorLastName,


### PR DESCRIPTION
### Problem

After the `BookForm` component submits the form with its values, the `books` state overwrites the `start_reading` and `stop_reading` values. This happens because the `BookForm` lacks the `start_reading` and `stop_reading` fields in its body. Then when the `BookForm` values are spread on the `handleUpdateBooks` function the `books` state is updated and will no longer contains the `start_reading` and `stop_reading` book properties.

### Fix

In the `handleUpdateBooks` function, the `...book` spread is added that acts as the book base. Then the rest of the properties are added. In this way, the `start_reading` and `stop_reading` will not be overwritten.

While I was working on the `BookForm` I realised that I can remove the `hidden` properties within the form because they have no effect.